### PR TITLE
roleRef has no namespace attribute

### DIFF
--- a/charts/redis-operator/templates/rbac.yaml
+++ b/charts/redis-operator/templates/rbac.yaml
@@ -65,6 +65,5 @@ subjects:
 roleRef:
   kind: Role
   name: {{ include "name" . | quote }}
-  namespace: {{ .Release.Namespace }}
   apiGroup: rbac.authorization.k8s.io
   


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/blob/v1.16.0/staging/src/k8s.io/api/rbac/v1/types.go#L91

Applying this yields:
```
ValidationError(RoleBinding.roleRef): unknown field "namespace" in io.k8s.api.rbac.v1.RoleRef
```